### PR TITLE
Adding Username Password Support

### DIFF
--- a/src/main/groovy/net/unicon/grouper/changelog/esb/publisher/ApplicationConfig.java
+++ b/src/main/groovy/net/unicon/grouper/changelog/esb/publisher/ApplicationConfig.java
@@ -18,9 +18,15 @@ public class ApplicationConfig {
     public AmqpTemplate amqpTemplate(@Value("${changeLog.consumer.esbAmqp.hostName}")
                                      String hostName,
                                      @Value("${changeLog.consumer.esbAmqp.defaultExchange}")
-                                     String defaultExchange) {
-
-        RabbitTemplate rabbitTemplate = new RabbitTemplate(new CachingConnectionFactory(hostName));
+                                     String defaultExchange,
+                                     @Value("${changeLog.consumer.esbAmqp.username}")
+                                     String username,
+                                     @Value("${changeLog.consumer.esbAmqp.password}")
+                                     String password) {
+        CachingConnectionFactory factory = new CachingConnectionFactory(hostName);
+        factory.setUsername(username);
+        factory.setPassword(password);
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(factory);
         rabbitTemplate.setExchange(defaultExchange);
         return rabbitTemplate;
     }


### PR DESCRIPTION
This is a minor change to ApplicationConfig.java to add username and password support for RabbitMQ. It defines two new properties:

changeLog.consumer.esbAmqp.username
changeLog.consumer.esbAmqp.password
For example:
changeLog.consumer.esbAmqp.username = midpoint
changeLog.consumer.esbAmqp.password = 5ecr3t
